### PR TITLE
Add master stable target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ VENV				?= $(BUILD)/venv/riab
 RIABVALUES			?= $(RIABDIR)/sdran-in-a-box-values.yaml
 RIABVALUES-LATEST	?= $(RIABDIR)/sdran-in-a-box-values.yaml
 RIABVALUES-V1.0.0	?= $(RIABDIR)/sdran-in-a-box-values-v1.0.0.yaml
+RIABVALUES-MS		?= $(RIABDIR)/sdran-in-a-box-values-master-stable.yaml
 CHARTDIR			?= $(WORKSPACE)/helm-charts
 AETHERCHARTDIR		?= $(CHARTDIR)/aether-helm-charts
 AETHERCHARTCID		?= 6b3a267e428402d6bb8531bd921c1d202bb338b2
@@ -55,7 +56,7 @@ cpu_model	:= $(shell lscpu | grep 'Model:' | awk '{print $$2}')
 os_vendor	:= $(shell lsb_release -i -s)
 os_release	:= $(shell lsb_release -r -s)
 
-.PHONY: riab-oai riab-ransim riab-oai-latest riab-oai-v1.0.0 riab-ransim-latest riab-ransim-v1.0.0 set-option-oai set-option-ransim set-stable-aether-chart set-latest-sdran-chart set-v1.0.0-sdran-chart set-latest-riab-values set-v1.0.0-riab-values fetch-all-charts omec oai oai-enb-cu oai-enb-du oai-ue ric atomix test-user-plane test-kpimon reset-oai reset-omec reset-atomix reset-ric reset-oai-test reset-ransim-test reset-test clean
+.PHONY: riab-oai riab-ransim riab-oai-latest riab-oai-v1.0.0 riab-ransim-latest riab-ransim-v1.0.0 riab-oai-master-stable riab-ransim-master-stable set-option-oai set-option-ransim set-stable-aether-chart set-latest-sdran-chart set-v1.0.0-sdran-chart set-latest-riab-values set-v1.0.0-riab-values set-master-stable-riab-values fetch-all-charts omec oai oai-enb-cu oai-enb-du oai-ue ric atomix test-user-plane test-kpimon reset-oai reset-omec reset-atomix reset-ric reset-oai-test reset-ransim-test reset-test clean
 
 riab-oai: set-option-oai $(M)/system-check $(M)/helm-ready set-stable-aether-chart set-latest-sdran-chart set-latest-riab-values omec ric oai
 riab-ransim: set-option-ransim $(M)/system-check $(M)/helm-ready set-latest-sdran-chart set-latest-riab-values ric
@@ -68,6 +69,9 @@ riab-ransim-v1.0.0: set-option-ransim $(M)/system-check $(M)/helm-ready set-v1.0
 
 riab-oai-dev: set-option-oai $(M)/system-check $(M)/helm-ready set-latest-riab-values omec ric oai
 riab-ransim-dev: set-option-ransim $(M)/system-check $(M)/helm-ready set-latest-riab-values ric
+
+riab-oai-master-stable: set-option-oai $(M)/system-check $(M)/helm-ready set-stable-aether-chart set-latest-sdran-chart set-master-stable-riab-values omec ric oai
+riab-ransim-master-stable: set-option-oai $(M)/system-check $(M)/helm-ready set-stable-aether-chart set-latest-sdran-chart set-master-stable-riab-values ric
 
 omec: $(M)/omec
 oai: set-option-oai $(M)/oai-enb-cu $(M)/oai-enb-du $(M)/oai-ue
@@ -102,6 +106,9 @@ set-latest-riab-values:
 
 set-v1.0.0-riab-values:
 	$(eval RIABVALUES=$(RIABVALUES-V1.0.0))
+
+set-master-stable-riab-values:
+	$(eval RIABVALUES=$(RIABVALUES-MS))
 
 fetch-all-charts:
 	cd $(AETHERCHARTDIR); \

--- a/configs/chart_values/onf-server-1-riab-values-master-stable.yaml
+++ b/configs/chart_values/onf-server-1-riab-values-master-stable.yaml
@@ -1,0 +1,188 @@
+# Copyright 2020-present Open Networking Foundation
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+
+# This chart vaule file is working for some VMs running in ONF servers - 10.128.100.131,132,251,255
+
+# cassandra values
+cassandra:
+  config:
+    cluster_size: 1
+    seed_size: 1
+
+resources:
+  enabled: false
+
+config:
+  spgwc:
+    pfcp: true
+    ueIpPool:
+      ip: 172.250.0.0 # if we use RiaB, Makefile script will override this value with the value defined in Makefile script.
+  upf:
+    name: "oaisim"
+    sriov:
+      enabled: false
+    hugepage:
+      enabled: false
+    cniPlugin: simpleovs
+    ipam: static
+    cfgFiles:
+      upf.json:
+        mode: af_packet
+  mme:
+    cfgFiles:
+      config.json:
+        mme:
+          mcc:
+            dig1: 2
+            dig2: 0
+            dig3: 8
+          mnc:
+            dig1: 0
+            dig2: 1
+            dig3: -1
+          apnlist:
+            internet: "spgwc"
+  hss:
+    bootstrap:
+      users:
+        - apn: "internet"
+          key: "465b5ce8b199b49faa5f0a2ee238a6bc"
+          opc: "d4416644f6154936193433dd20a0ace0"
+          sqn: 96
+          imsiStart: "208014567891201"
+          msisdnStart: "1122334455"
+          count: 10
+      mmes:
+        - id: 1
+          mme_identity: mme.riab.svc.cluster.local
+          mme_realm: riab.svc.cluster.local
+          isdn: "19136246000"
+          unreachability: 1
+  oai-enb-cu:
+    networks:
+      f1:
+        interface: eno1 # if we use RiaB, Makefile script will automatically apply appropriate interface name
+        address: 10.128.100.100 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+      s1mme:
+        interface: eno1 # if we use RiaB, Makefile script will automatically apply appropriate interface name
+      s1u:
+        interface: enb
+  oai-enb-du:
+    mode: nfapi #or local_L1 for USRP and BasicSim
+    networks:
+      f1:
+        interface: eno1 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+        address: 10.128.100.100 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+      nfapi:
+        interface: eno1 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+        address: 10.128.100.100 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+  oai-ue:
+    networks:
+      nfapi:
+        interface: eno1 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+        address: 10.128.100.100 #if we use RiaB, Makefile script will automatically apply appropriate IP address
+  onos-e2t:
+    enabled: "yes"
+    networks:
+      e2:
+        address: 127.0.0.1 # if we use RiaB, Makefile script will automatically apply appropriate interface name
+        port: 36421
+
+# for the master-stable, RiaB uses the image tags defined the Helm chart - not latest
+# For ONOS-RIC
+# onos-topo:
+#   image:
+#     pullPolicy: IfNotPresent
+#     repository: onosproject/onos-topo
+#     tag: latest
+# onos-config:
+#   image:
+#     pullPolicy: IfNotPresent
+#     repository: onosproject/onos-config
+#     tag: latest
+# onos-e2t:
+#   service:
+#     external:
+#       enabled: true
+#     e2:
+#      nodePort: 36421
+#   image:
+#     pullPolicy: IfNotPresent
+#     repository: onosproject/onos-e2t
+#     tag: latest
+#   servicemodels:
+#   - name: e2sm_kpm
+#     version: 1.0.0
+#     image:
+#       repository: onosproject/service-model-docker-e2sm_kpm-1.0.0
+#       tag: v0.7.6
+#       pullPolicy: IfNotPresent
+#   - name: e2sm_rc_pre
+#     version: 1.0.0
+#     image:
+#       repository: onosproject/service-model-docker-e2sm_rc_pre-1.0.0
+#       tag: v0.7.6
+#       pullPolicy: IfNotPresent
+# onos-e2sub:
+#   image:
+#     pullPolicy: IfNotPresent
+#     repository: onosproject/onos-e2sub
+#     tag: latest
+# onos-sdran-cli:
+#   image:
+#     pullPolicy: IfNotPresent
+#     repository: onosproject/onos-sdran-cli
+#     tag: latest
+# onos-kpimon:
+#   image:
+#     pullPolicy: IfNotPresent
+#     repository: onosproject/onos-kpimon
+#     tag: latest
+
+# For OMEC & OAI
+images:
+  pullPolicy: IfNotPresent
+  tags:
+# For OMEC - Those images are stable image for RiaB
+# latest Aether helm chart commit ID: 3d1e936e87b4ddae784a33f036f87899e9d00b95
+#    init: docker.io/omecproject/pod-init:1.0.0
+#    depCheck: quay.io/stackanetes/kubernetes-entrypoint:v0.3.1
+    hssdb: docker.io/onosproject/riab-hssdb:v1.0.0
+    hss: docker.io/onosproject/riab-hss:v1.0.0
+    mme: docker.io/onosproject/riab-nucleus-mme:v1.0.0
+    spgwc: docker.io/onosproject/riab-spgw:v1.0.0-onfvm-1
+    pcrf: docker.io/onosproject/riab-pcrf:v1.0.0
+    pcrfdb: docker.io/onosproject/riab-pcrfdb:v1.0.0
+    bess: docker.io/onosproject/riab-bess-upf:v1.0.0-onfvm-1
+    pfcpiface: docker.io/onosproject/riab-pfcpiface:v1.0.0-onfvm-1
+# For OAI
+    oaicucp: docker.io/onosproject/oai-enb-cu:latest
+    oaidu: docker.io/onosproject/oai-enb-du:latest
+    oaiue: docker.io/onosproject/oai-ue:latest
+
+# For SD-RAN Umbrella chart:
+# ONOS-KPIMON xAPP is imported in the RiaB by default
+import:
+  onos-kpimon:
+    enabled: true
+# Other ONOS-RIC micro-services
+#   onos-topo:
+#     enabled: true
+#   onos-e2t:
+#     enabled: true
+#   onos-e2sub:
+#     enabled: true
+#   onos-o1t:
+#     enabled: false
+#   onos-config:
+#     enabled: true
+#   onos-sdran-cli:
+#     enabled: true
+# ran-simulator chart is automatically imported when pushing ransim option
+#   ran-simulator:
+#     enabled: false
+#   onos-gui:
+#     enabled: false
+#   nem-monitoring:
+#     enabled: false


### PR DESCRIPTION
It uses a latest version of sd-ran umbrella chart but not latest image.
RiaB will use the image tags defined in the latest umbrella chart.