### PR TITLE
Change cache-storage-controller to atomix-memory-storage

### DIFF
--- a/mk/infra.mk
+++ b/mk/infra.mk
@@ -80,8 +80,8 @@ $(M)/fabric: | $(M)/setup /opt/cni/bin/simpleovs /opt/cni/bin/static
 $(M)/atomix: | $(M)/k8s-ready
 	kubectl get po -n kube-system | grep atomix-controller | grep -v Terminating || kubectl create -f https://raw.githubusercontent.com/atomix/kubernetes-controller/master/deploy/atomix-controller.yaml
 	kubectl get po -n kube-system | grep raft-storage-controller | grep -v Terminating || kubectl create -f https://raw.githubusercontent.com/atomix/raft-storage-controller/master/deploy/raft-storage-controller.yaml
-	kubectl get po -n kube-system | grep cache-storage-controller | grep -v Terminating || kubectl create -f https://raw.githubusercontent.com/atomix/cache-storage-controller/master/deploy/cache-storage-controller.yaml
-	@until [ $$(kubectl get po -n kube-system | grep -e atomix-controller -e raft-storage-controller -e cache-storage-controller | grep 1/1 | wc -l) == 3 ]; do sleep 1; done
+	kubectl get po -n kube-system | grep atomix-memory-storage | grep -v Terminating || kubectl create -f https://raw.githubusercontent.com/atomix/atomix-memory-storage/master/deploy/atomix-memory-storage.yaml
+	@until [ $$(kubectl get po -n kube-system | grep -e atomix-controller -e raft-storage-controller -e atomix-memory-storage | grep 1/1 | wc -l) == 3 ]; do sleep 1; done
 	touch $@
 
 $(M)/onos-operator: | $(M)/k8s-ready

--- a/mk/reset-clean.mk
+++ b/mk/reset-clean.mk
@@ -31,7 +31,7 @@ reset-omec:
 
 reset-atomix:
 	kubectl delete -f https://raw.githubusercontent.com/atomix/raft-storage-controller/master/deploy/raft-storage-controller.yaml || true
-	kubectl delete -f https://raw.githubusercontent.com/atomix/cache-storage-controller/master/deploy/cache-storage-controller.yaml || true
+	kubectl delete -f https://raw.githubusercontent.com/atomix/atomix-memory-storage/master/deploy/atomix-memory-storage.yaml || true
 	kubectl delete -f https://raw.githubusercontent.com/atomix/kubernetes-controller/master/deploy/atomix-controller.yaml || true
 	cd $(M); rm -f atomix
 


### PR DESCRIPTION
Change is made because RiaB is hanging at this point while building `atomix`.

`kubectl get po -n kube-system | grep cache-storage-controller | grep -v Terminating || kubectl create -f https://raw.githubusercontent.com/atomix/cache-storage-controller/master/deploy/cache-storage-controller.yaml
customresourcedefinition.apiextensions.k8s.io/cachestorageclasses.storage.cloud.atomix.io created
serviceaccount/atomix-memory-storage-controller created
clusterrole.rbac.authorization.k8s.io/atomix-memory-storage-controller created
clusterrolebinding.rbac.authorization.k8s.io/atomix-memory-storage-controller created
deployment.apps/atomix-memory-storage-controller created`

Tested on local and RiaB works as expected.