### PR TITLE
Setting stable version to a know onos-operator version

### DIFF
--- a/mk/infra.mk
+++ b/mk/infra.mk
@@ -155,7 +155,7 @@ else ifeq ($(VER), v1.2.0)
 else ifeq ($(VER), v1.3.0)
 	helm install onos-operator onos/onos-operator -n kube-system --version 0.4.14 --wait || true
 else ifeq ($(VER), stable)
-	helm install onos-operator onos/onos-operator -n kube-system --wait || true
+	helm install onos-operator onos/onos-operator -n kube-system --version 0.4.14 --wait || true
 else ifeq ($(VER), latest)
 	helm install onos-operator onos/onos-operator -n kube-system --wait || true
 else ifeq ($(VER), dev)


### PR DESCRIPTION
`stable` is the `DEFAULT_VER` and `stable` should not depend on a moving target.

Having a fixed version of the `onos-operator` chart will allow user to have repeatable deployment.

It will also resolve the temporary issue when using the `latest` onos-operator chart in which support for the CRD:
```
apiVersion: config.onosproject.org/v1beta1
kind: Model
```
has been dropped.