### PR TITLE
Add checks to support AMD processors

### DIFF
--- a/MakefileVar.mk
+++ b/MakefileVar.mk
@@ -87,6 +87,7 @@ STATIC_UE_IP_POOL				?= 172.249.0.0
 STATIC_UE_IP_MASK				?= 16
 
 # For system check
+CPU_VENDOR						:= $(shell lscpu | grep 'Vendor ID:' | awk '{print $$3}')
 CPU_FAMILY						:= $(shell lscpu | grep 'CPU family:' | awk '{print $$3}')
 CPU_MODEL						:= $(shell lscpu | grep 'Model:' | awk '{print $$2}')
 OS_VENDOR						:= $(shell lsb_release -i -s)

--- a/mk/preliminaries.mk
+++ b/mk/preliminaries.mk
@@ -7,13 +7,30 @@ PRELIMINARIES_PHONY			:= preliminaries
 preliminaries: $(M) $(M)/system-check $(M)/setup
 
 $(M)/system-check: | $(M) $(M)/repos
-	@if [[ $(CPU_FAMILY) -eq 6 ]]; then \
-		if [[ $(CPU_MODEL) -lt 60 ]]; then \
-			echo "FATAL: haswell CPU or newer is required."; \
+	@if [[ $(CPU_VENDOR) == "GenuineIntel" ]]; then \
+		if [[ $(CPU_FAMILY) -eq 6 ]]; then \
+			if [[ $(CPU_MODEL) -lt 60 ]]; then \
+				echo "FATAL: haswell CPU or newer is required."; \
+				exit 1; \
+			fi \
+		else \
+			echo "FATAL: unsupported CPU family."; \
 			exit 1; \
 		fi \
-	else \
-		echo "FATAL: unsupported CPU family."; \
+	fi
+	@if [[ $(CPU_VENDOR) == "AuthenticAMD" ]]; then \
+		if [[ $(CPU_FAMILY) -gt 22 ]]; then \
+			if [[ $(CPU_MODEL) -lt 1 ]]; then \
+				echo "FATAL: ryzen 1 CPU or newer is required."; \
+				exit 1; \
+			fi \
+		else \
+			echo "FATAL: unsupported CPU family."; \
+			exit 1; \
+		fi \
+	fi
+	@if [[ ! (($(CPU_VENDOR) == "GenuineIntel") || ($(CPU_VENDOR) == "AuthenticAMD")) ]]; then \
+		echo "FATAL: unsupported CPU vendor."; \
 		exit 1; \
 	fi
 	@if [[ $(OS_VENDOR) =~ (Ubuntu) ]] || [[ $(OS_VENDOR) =~ (Debian) ]]; then \


### PR DESCRIPTION
This PR adds two checks, one for CPU_VENDOR (Intel, AMD or another) and a CPU Family requiring at least the AMD Ryzen 1 family, which supports all instructions needed by OAI.